### PR TITLE
fix powershell scripts message quoting

### DIFF
--- a/powershell/shutDown.ps1
+++ b/powershell/shutDown.ps1
@@ -1,4 +1,4 @@
 $port= new-Object System.IO.Ports.SerialPort COM4,9600,None,8,one
 $port.open()
-$port.WriteLine('power/off')
+$port.WriteLine('`power/off~')
 $port.close()

--- a/powershell/startUp.ps1
+++ b/powershell/startUp.ps1
@@ -1,4 +1,4 @@
 $port= new-Object System.IO.Ports.SerialPort COM4,9600,None,8,one
 $port.open()
-$port.WriteLine('power/on')
+$port.WriteLine('`power/on~')
 $port.close()


### PR DESCRIPTION
Powershell script quoting did not include the ` and ~ markers needed to mark the start and end of the message. 